### PR TITLE
Use QString instead of QStringLiteral("")

### DIFF
--- a/QPathEdit/qpathedit.cpp
+++ b/QPathEdit/qpathedit.cpp
@@ -60,7 +60,7 @@ QPathEdit::QPathEdit(QPathEdit::PathMode pathMode, QWidget *parent, QPathEdit::S
 	connect(dialog, &QFileDialog::fileSelected, this, &QPathEdit::dialogFileSelected);
 
 	//setup completer
-	completerModel->setRootPath(QStringLiteral(""));
+    completerModel->setRootPath(QString());
 	completerModel->setNameFilterDisables(false);
 	connect(completerModel, &QFileSystemModel::directoryLoaded, pathCompleter, [this](QString){
 		pathCompleter->complete();


### PR DESCRIPTION
Hey,

First of all huge thanks for sharing, maintaining this project!

I just came over this minor improvement while checked one of my projects which included the QPathEdit.
See:
http://blog.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral/
(Section "Do not use QStringLiteral for empty strings")