### PR TITLE
Fix #3: add an accessor method to the currently displayed path

### DIFF
--- a/QPathEdit/qpathedit.cpp
+++ b/QPathEdit/qpathedit.cpp
@@ -183,6 +183,11 @@ QString QPathEdit::path() const
 	return currentValidPath;
 }
 
+QString QPathEdit::editPath() const
+{
+	return edit->text();
+}
+
 QUrl QPathEdit::pathUrl() const
 {
 	return QUrl::fromLocalFile(currentValidPath);
@@ -353,6 +358,7 @@ void QPathEdit::showDialog()
 
 void QPathEdit::updateValidInfo(const QString &path)
 {
+	emit editPathChanged(path);
 	completerModel->index(QFileInfo(path).dir().absolutePath());//enforce "directory loading"
 	if(edit->hasAcceptableInput()) {
 		if(!wasPathValid) {

--- a/QPathEdit/qpathedit.h
+++ b/QPathEdit/qpathedit.h
@@ -44,6 +44,8 @@ class DESIGNER_PLUGIN_EXPORT QPathEdit : public QWidget
 	Q_PROPERTY(QString defaultDirectory READ defaultDirectory WRITE setDefaultDirectory)
 	//! Holds the currently entered, valid path
 	Q_PROPERTY(QString path READ path WRITE setPath RESET clear NOTIFY pathChanged)
+	//! Holds the currently entered text which might not be a valid path
+	Q_PROPERTY(QString editPath READ editPath NOTIFY editPathChanged)
 	//! Holds the information, whether the current edits contents are a valid path or not
 	Q_PROPERTY(bool acceptableInput READ hasAcceptableInput NOTIFY acceptableInputChanged)
 	//! Specifiy a placeholder to be shown if no path is entered
@@ -87,6 +89,8 @@ public:
 	QString defaultDirectory() const;
 	//! READ-ACCESSOR for QPathEdit::path
 	QString path() const;
+	//! READ-ACCESSOR for QPathEdit::editPath
+	QString editPath() const;
 	//! Returns the entered path as an QUrl
 	QUrl pathUrl() const;
 	//! READ-ACCESSOR for QPathEdit::acceptableInput
@@ -142,6 +146,8 @@ public slots:
 signals:
 	//! NOTIFY-ACCESSOR for QPathEdit::path
 	void pathChanged(QString path);
+	//! NOTIFY-ACCESSOR for QPathEdit::editPath
+	void editPathChanged(QString path);
 	//! NOTIFY-ACCESSOR for QPathEdit::acceptableInput
 	void acceptableInputChanged(bool acceptableInput);
 


### PR DESCRIPTION
This PR adds an accessor method to the currently displayed path. (It was not accessible through the QPathEdit::path() member in the case if it was invalid).